### PR TITLE
Fix extension count in memory savings

### DIFF
--- a/modules/memory-tracker.js
+++ b/modules/memory-tracker.js
@@ -79,7 +79,10 @@ async function estimatePotentialSavings() {
     // Aktif tabları ve uzantıları al
     const tabs = await chrome.tabs.query({});
     const extensions = await chrome.management.getAll();
-    const activeExtensions = extensions.filter(ext => ext.enabled && ext.type !== 'theme');
+    // Exclude this extension from the list to avoid overestimating savings
+    const activeExtensions = extensions.filter(
+      ext => ext.enabled && ext.type !== 'theme' && ext.id !== chrome.runtime.id
+    );
     
     // Aktif, Chrome tarafından donmuş ve bizim tarafımızdan donmuş tabları ayır
     const activeTabs = tabs.filter(tab => !tab.discarded && !frozenTabsSet.has(tab.id));


### PR DESCRIPTION
## Summary
- ensure extension savings calculation ignores the booster itself

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e8de3d9c08329b67a93a771c12b13